### PR TITLE
add support for async functions in the async-then rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Then configure the rules you want to use under the rules section.
 
 | Name               | Description                                                                                                         |
 | -------------      | -------------                                                                                                       |
-| async-then         | If you assume asynchronous steps then your Then steps should either return a promise or provide a callback function |
+| async-then         | If you assume asynchronous steps then your Then steps should either be an async function, return a promise or provide a callback function |
 | no-restricted-tags | Restrict usage of specified tags                                                                                    |
 | no-arrow-functions | Restrict usage of arrow functions on step definitions                                                               |
 

--- a/lib/rules/async-then.js
+++ b/lib/rules/async-then.js
@@ -39,11 +39,18 @@ module.exports = function(context) {
     );
   }
 
+  function isAsyncFunction(func) {
+    return !!func.async;
+  }
+
   return {
     CallExpression: function(node) {
       if (isThenStep(node)) {
         const stepBody = node.arguments[node.arguments.length - 1];
 
+        if (isAsyncFunction(stepBody)) {
+          return;
+        }
         if (doesNotHaveCallback(stepBody) && didNotReturnAnythingIn(stepBody)) {
           context.report(
             node.callee.property || node.callee,

--- a/tests/lib/rules/async-then.js
+++ b/tests/lib/rules/async-then.js
@@ -1,8 +1,12 @@
 const rule = require('../../../lib/rules/async-then');
 const RuleTester = require('eslint').RuleTester;
 
-new RuleTester().run('async-then', rule, {
+const tester = new RuleTester({parserOptions: {ecmaVersion: '2017'}});
+
+tester.run('async-then', rule, {
   valid: [
+    'this.Then(/step/, async function () {})',
+    'Then(/step/, async function () {})',
     'this.Then(/step/, function () {return "anything";})',
     'Then(/step/, function () {return "anything";})',
     'this.Then(/step/, function (done) {})',


### PR DESCRIPTION
So you can take advantage of this rule if you are using async/await syntax.

It exits as soon as it detects an async function, as they always implicitly return a promise so we don't need to check what's being returned.