### PR TITLE
add new "expression-type" rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Then configure the rules you want to use under the rules section.
 {
     "rules": {
         "cucumber/async-then": 2,
+        "cucumber/expression-type": 2,
         "cucumber/no-restricted-tags": [2, "wip", "broken", "foo"],
         "cucumber/no-arrow-functions": 2
     }
@@ -47,9 +48,10 @@ Then configure the rules you want to use under the rules section.
 
 | Name               | Description                                                                                                         |
 | -------------      | -------------                                                                                                       |
-| async-then         | If you assume asynchronous steps then your Then steps should either be an async function, return a promise or provide a callback function |
-| no-restricted-tags | Restrict usage of specified tags                                                                                    |
-| no-arrow-functions | Restrict usage of arrow functions on step definitions                                                               |
+| [async-then](docs/rules/async-then.md)                 | If you assume asynchronous steps then your Then steps should either be an async function, return a promise or provide a callback function |
+| [expression-type](docs/rules/expression-type.md)       | Restrict steps to either Cucumber Expressions or Regular Expressions                                                |
+| [no-restricted-tags](docs/rules/no-restricted-tags.md) | Restrict usage of specified tags                                                                                    |
+| [no-arrow-functions](docs/rules/no-arrow-functions.md) | Restrict usage of arrow functions on step definitions                                                               |
 
 ## For Maintainers
 

--- a/docs/rules/expression-type.md
+++ b/docs/rules/expression-type.md
@@ -1,0 +1,45 @@
+# Ensures consistent usage of one type of expression (expression-type)
+
+Your project might have a convention to use either [Cucumber Expressions](https://cucumber.io/docs/cucumber/cucumber-expressions/) or [Regular Expressions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions) to match steps - but not both.
+
+## Rule Details
+
+This rule allows you to enforce that either Cucumber Expressions (default) or Regular Expressions are used exclusively in your steps.
+
+Examples of **incorrect** code for this rule:
+
+```js
+/*eslint cucumber/expression-type: "error"*/
+
+Then(/some step/, function () {
+  // step code
+});
+```
+
+Examples of **correct** code for this rule:
+
+```js
+/*eslint cucumber/expression-type: "error"*/
+
+Then("some step", function () {
+  // step code
+});
+```
+
+## Options
+
+The rule has a single option (defaults to "Cucumber") that allows you to specify which type of expression to mandate, whose value can be either "Cucumber" or "RegExp".
+
+Examples of incorrect code for this rule with a sample `"RegExp"` option:
+
+```js
+/*eslint cucumber/expression-type: [ "error", "RegExp" ]*/
+
+Then("some step", function () {
+  // step code
+});
+```
+
+## When Not To Use It
+
+When don't mind which type of expression is used in steps.

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@ const _ = require('lodash');
 module.exports = {
   rules: {
     'async-then': require('./rules/async-then'),
+    'expression-type': require('./rules/expression-type'),
     'no-restricted-tags': require('./rules/no-restricted-tags'),
     'no-arrow-functions': require('./rules/no-arrow-functions')
   },

--- a/lib/rules/expression-type.js
+++ b/lib/rules/expression-type.js
@@ -1,0 +1,66 @@
+const STEP_NAMES = ['Given', 'When', 'Then'];
+const EXPRESSION_TYPES  = {
+  'Cucumber': {
+    check(expressionNode) {
+      return expressionNode.type === 'Literal' && typeof expressionNode.value === 'string'
+    },
+    message: 'Only Cucumber Expressions should be used to match steps'
+  },
+  'RegExp': {
+    check(expressionNode) {
+      return expressionNode.type === 'Literal' && !!expressionNode.regex
+    },
+    message: 'Only Regular Expressions should be used to match steps'
+  }
+};
+
+function isStep(node) {
+  return isCucumberOneStep(node) || isCucumberTwoPlusStep(node);
+}
+
+function isCucumberOneStep(node) {
+  return (
+    node.callee &&
+    node.callee.object &&
+    node.callee.object.type === 'ThisExpression' &&
+    node.callee.property &&
+    STEP_NAMES.indexOf(node.callee.property.name) !== -1
+  );
+}
+
+function isCucumberTwoPlusStep(node) {
+  return (
+    node.type === 'CallExpression' &&
+    node.callee &&
+    node.callee.type === 'Identifier' &&
+    STEP_NAMES.indexOf(node.callee.name) !== -1
+  );
+}
+
+module.exports = {
+  meta: {
+    schema: [
+      {
+        type: 'string',
+        enum: ['Cucumber', 'RegExp'],
+        default: 'Cucumber'
+      }
+    ]
+  },
+  create: function(context) {
+    const preferredType = context.options[0] || 'Cucumber';
+    return {
+      CallExpression: function(node) {
+        if (isStep(node)) {
+          const expressionNode = node.arguments[0];
+          if (!EXPRESSION_TYPES[preferredType].check(expressionNode)) {
+            context.report(
+              expressionNode,
+              EXPRESSION_TYPES[preferredType].message
+            );
+          }
+        }
+      }
+    };
+  }
+};

--- a/lib/rules/expression-type.js
+++ b/lib/rules/expression-type.js
@@ -1,14 +1,17 @@
 const STEP_NAMES = ['Given', 'When', 'Then'];
-const EXPRESSION_TYPES  = {
-  'Cucumber': {
+const EXPRESSION_TYPES = {
+  Cucumber: {
     check(expressionNode) {
-      return expressionNode.type === 'Literal' && typeof expressionNode.value === 'string'
+      return (
+        expressionNode.type === 'Literal' &&
+        typeof expressionNode.value === 'string'
+      );
     },
     message: 'Only Cucumber Expressions should be used to match steps'
   },
-  'RegExp': {
+  RegExp: {
     check(expressionNode) {
-      return expressionNode.type === 'Literal' && !!expressionNode.regex
+      return expressionNode.type === 'Literal' && !!expressionNode.regex;
     },
     message: 'Only Regular Expressions should be used to match steps'
   }

--- a/tests/lib/rules/expression-type.js
+++ b/tests/lib/rules/expression-type.js
@@ -30,7 +30,7 @@ tester.run('expression-type', rule, {
       code: 'this.Given(/step/, function () {})',
       errors: [
         {
-          message: "Only Cucumber Expressions should be used to match steps"
+          message: 'Only Cucumber Expressions should be used to match steps'
         }
       ]
     },
@@ -38,7 +38,7 @@ tester.run('expression-type', rule, {
       code: 'Given(/step/, function () {})',
       errors: [
         {
-          message: "Only Cucumber Expressions should be used to match steps"
+          message: 'Only Cucumber Expressions should be used to match steps'
         }
       ]
     },
@@ -46,7 +46,7 @@ tester.run('expression-type', rule, {
       code: 'this.When(/step/, function () {})',
       errors: [
         {
-          message: "Only Cucumber Expressions should be used to match steps"
+          message: 'Only Cucumber Expressions should be used to match steps'
         }
       ]
     },
@@ -54,7 +54,7 @@ tester.run('expression-type', rule, {
       code: 'When(/step/, function () {})',
       errors: [
         {
-          message: "Only Cucumber Expressions should be used to match steps"
+          message: 'Only Cucumber Expressions should be used to match steps'
         }
       ]
     },
@@ -62,7 +62,7 @@ tester.run('expression-type', rule, {
       code: 'this.Then(/step/, function () {})',
       errors: [
         {
-          message: "Only Cucumber Expressions should be used to match steps"
+          message: 'Only Cucumber Expressions should be used to match steps'
         }
       ]
     },
@@ -70,7 +70,7 @@ tester.run('expression-type', rule, {
       code: 'Then(/step/, function () {})',
       errors: [
         {
-          message: "Only Cucumber Expressions should be used to match steps"
+          message: 'Only Cucumber Expressions should be used to match steps'
         }
       ]
     },
@@ -80,7 +80,7 @@ tester.run('expression-type', rule, {
       code: 'Given(/step/, function () {})',
       errors: [
         {
-          message: "Only Cucumber Expressions should be used to match steps"
+          message: 'Only Cucumber Expressions should be used to match steps'
         }
       ],
       options: ['Cucumber']
@@ -89,7 +89,7 @@ tester.run('expression-type', rule, {
       code: 'When(/step/, function () {})',
       errors: [
         {
-          message: "Only Cucumber Expressions should be used to match steps"
+          message: 'Only Cucumber Expressions should be used to match steps'
         }
       ],
       options: ['Cucumber']
@@ -98,7 +98,7 @@ tester.run('expression-type', rule, {
       code: 'Then(/step/, function () {})',
       errors: [
         {
-          message: "Only Cucumber Expressions should be used to match steps"
+          message: 'Only Cucumber Expressions should be used to match steps'
         }
       ],
       options: ['Cucumber']
@@ -109,7 +109,7 @@ tester.run('expression-type', rule, {
       code: 'Given("step", function () {})',
       errors: [
         {
-          message: "Only Regular Expressions should be used to match steps"
+          message: 'Only Regular Expressions should be used to match steps'
         }
       ],
       options: ['RegExp']
@@ -118,7 +118,7 @@ tester.run('expression-type', rule, {
       code: 'When("step", function () {})',
       errors: [
         {
-          message: "Only Regular Expressions should be used to match steps"
+          message: 'Only Regular Expressions should be used to match steps'
         }
       ],
       options: ['RegExp']
@@ -127,7 +127,7 @@ tester.run('expression-type', rule, {
       code: 'Then("step", function () {})',
       errors: [
         {
-          message: "Only Regular Expressions should be used to match steps"
+          message: 'Only Regular Expressions should be used to match steps'
         }
       ],
       options: ['RegExp']

--- a/tests/lib/rules/expression-type.js
+++ b/tests/lib/rules/expression-type.js
@@ -1,0 +1,136 @@
+const rule = require('../../../lib/rules/expression-type');
+const RuleTester = require('eslint').RuleTester;
+
+const tester = new RuleTester({parserOptions: {ecmaVersion: '2017'}});
+
+tester.run('expression-type', rule, {
+  valid: [
+    // no option specified - default to cucumber
+    'this.Given("step", function () {})',
+    'Given("step", function () {})',
+    'this.Then("step", function () {})',
+    'Then("step", function () {})',
+    'this.When("step", function () {})',
+    'When("step", function () {})',
+
+    // cucumber option
+    {code: 'Given("step", function () {})', options: ['Cucumber']},
+    {code: 'Then("step", function () {})', options: ['Cucumber']},
+    {code: 'When("step", function () {})', options: ['Cucumber']},
+
+    // regex option
+    {code: 'Given(/step/, function () {})', options: ['RegExp']},
+    {code: 'Then(/step/, function () {})', options: ['RegExp']},
+    {code: 'When(/step/, function () {})', options: ['RegExp']}
+  ],
+
+  invalid: [
+    // no option specified - default to cucumber
+    {
+      code: 'this.Given(/step/, function () {})',
+      errors: [
+        {
+          message: "Only Cucumber Expressions should be used to match steps"
+        }
+      ]
+    },
+    {
+      code: 'Given(/step/, function () {})',
+      errors: [
+        {
+          message: "Only Cucumber Expressions should be used to match steps"
+        }
+      ]
+    },
+    {
+      code: 'this.When(/step/, function () {})',
+      errors: [
+        {
+          message: "Only Cucumber Expressions should be used to match steps"
+        }
+      ]
+    },
+    {
+      code: 'When(/step/, function () {})',
+      errors: [
+        {
+          message: "Only Cucumber Expressions should be used to match steps"
+        }
+      ]
+    },
+    {
+      code: 'this.Then(/step/, function () {})',
+      errors: [
+        {
+          message: "Only Cucumber Expressions should be used to match steps"
+        }
+      ]
+    },
+    {
+      code: 'Then(/step/, function () {})',
+      errors: [
+        {
+          message: "Only Cucumber Expressions should be used to match steps"
+        }
+      ]
+    },
+
+    // cucumber option
+    {
+      code: 'Given(/step/, function () {})',
+      errors: [
+        {
+          message: "Only Cucumber Expressions should be used to match steps"
+        }
+      ],
+      options: ['Cucumber']
+    },
+    {
+      code: 'When(/step/, function () {})',
+      errors: [
+        {
+          message: "Only Cucumber Expressions should be used to match steps"
+        }
+      ],
+      options: ['Cucumber']
+    },
+    {
+      code: 'Then(/step/, function () {})',
+      errors: [
+        {
+          message: "Only Cucumber Expressions should be used to match steps"
+        }
+      ],
+      options: ['Cucumber']
+    },
+
+    // regexp option
+    {
+      code: 'Given("step", function () {})',
+      errors: [
+        {
+          message: "Only Regular Expressions should be used to match steps"
+        }
+      ],
+      options: ['RegExp']
+    },
+    {
+      code: 'When("step", function () {})',
+      errors: [
+        {
+          message: "Only Regular Expressions should be used to match steps"
+        }
+      ],
+      options: ['RegExp']
+    },
+    {
+      code: 'Then("step", function () {})',
+      errors: [
+        {
+          message: "Only Regular Expressions should be used to match steps"
+        }
+      ],
+      options: ['RegExp']
+    }
+  ]
+});


### PR DESCRIPTION
> Your project might have a convention to use either [Cucumber Expressions](https://cucumber.io/docs/cucumber/cucumber-expressions/) or [Regular Expressions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions) to match steps - but not both.
> 
> This rule allows you to enforce that either Cucumber Expressions (default) or Regular Expressions are used exclusively in your steps.

My use case is where we only use Cucumber expressions, as they're (IMO) more deterministic, easier for folks to understand, and easier to process with tooling (to generate a step library etc).