### PR TITLE
fix(async-then): validate expressions to prevent type errors with arrow functions

### DIFF
--- a/lib/rules/async-then.js
+++ b/lib/rules/async-then.js
@@ -44,16 +44,16 @@ function getCucumberTwoPlusMatchedStepOrHook(node, targetWords) {
 }
 
 function didNotReturnAnythingIn(func) {
-  const statements = func.body.body;
+  const statements = func.body && func.body.body;
   return (
-    !statements.length ||
+    !statements || !statements.length ||
     statements[statements.length - 1].type !== 'ReturnStatement'
   );
 }
 
 function doesNotHaveCallback(func) {
   return (
-    !func.params.length ||
+    !func.params || !func.params.length ||
     !CALLBACK_NAMES.exec(func.params[func.params.length - 1].name)
   );
 }


### PR DESCRIPTION
closes #17 